### PR TITLE
Fix instantiating extra `PrismaClient` in dev

### DIFF
--- a/.changeset/lazy-badgers-love.md
+++ b/.changeset/lazy-badgers-love.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/keystone-nextjs-auth': minor
+---
+
+Allow custom session `get`, `start` and `end`

--- a/.changeset/silver-carrots-ring.md
+++ b/.changeset/silver-carrots-ring.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/keystone-nextjs-auth': patch
+---
+
+Set prisma and query on global in dev to prevent instantiating extra `PrismaClient` instances

--- a/packages/keystone-nextjs-auth/src/index.ts
+++ b/packages/keystone-nextjs-auth/src/index.ts
@@ -233,6 +233,7 @@ export function createAuth<GeneratedListTypes extends BaseListTypeInfo>({
         };
       },
       end: async ({ res, req, createContext }) => {
+        await end({ res, req, createContext });
         const TOKEN_NAME =
           process.env.NODE_ENV === 'production'
             ? '__Secure-next-auth.session-token'
@@ -250,7 +251,6 @@ export function createAuth<GeneratedListTypes extends BaseListTypeInfo>({
             domain: url.parse(req.url as string).hostname as string,
           })
         );
-        await end({ res, req, createContext });
       },
     };
   };

--- a/packages/keystone-nextjs-auth/src/pages/NextAuthPage.tsx
+++ b/packages/keystone-nextjs-auth/src/pages/NextAuthPage.tsx
@@ -4,28 +4,28 @@ import { Provider } from 'next-auth/providers';
 import { JWTOptions } from 'next-auth/jwt';
 import { validateNextAuth } from '../lib/validateNextAuth';
 
-export type CoreNextAuthPageProps = {
+export type NextAuthTemplateProps = {
   autoCreate: boolean;
-  cookies?: Partial<CookiesOptions>;
-  events?: Partial<EventCallbacks>;
   identityField: string;
-  jwt?: Partial<JWTOptions>;
   listKey: string;
-  pages?: Partial<PagesOptions>;
-  providers?: Provider[];
-  resolver?: (args: { user: any; profile: any; account: any }) => Promise<{
-    [key: string]: boolean | string | number;
-  }>;
   sessionData: string | undefined;
   sessionSecret: string;
 };
 
-type NextAuthGglProps = {
-  mutationName?: string;
-  query?: KeystoneListsAPI<any>;
-};
+export type CoreNextAuthPageProps = {
+  cookies?: Partial<CookiesOptions>;
+  events?: Partial<EventCallbacks>;
+  jwt?: Partial<JWTOptions>;
+  pages?: Partial<PagesOptions>;
+  providers: Provider[];
+  resolver?: (args: { user: any; profile: any; account: any }) => Promise<{
+    [key: string]: boolean | string | number;
+  }>;
+} & NextAuthTemplateProps;
 
-export type NextAuthPageProps = CoreNextAuthPageProps & NextAuthGglProps;
+export type NextAuthPageProps = CoreNextAuthPageProps & {
+  query: KeystoneListsAPI<any>;
+};
 
 export default function NextAuthPage(props: NextAuthPageProps) {
   const {

--- a/packages/keystone-nextjs-auth/src/templates/auth.ts
+++ b/packages/keystone-nextjs-auth/src/templates/auth.ts
@@ -1,5 +1,5 @@
 import ejs from 'ejs';
-import { NextAuthPageProps } from '../pages/NextAuthPage';
+import { CoreNextAuthPageProps } from '../pages/NextAuthPage';
 
 const template = `
 import getNextAuthPage from '@opensaas/keystone-nextjs-auth/pages/NextAuthPage';
@@ -19,7 +19,7 @@ export default getNextAuthPage({
     });
   `;
 
-type AuthTemplateOptions = NextAuthPageProps;
+type AuthTemplateOptions = CoreNextAuthPageProps;
 
 export const authTemplate = ({
   autoCreate,

--- a/packages/keystone-nextjs-auth/src/templates/auth.ts
+++ b/packages/keystone-nextjs-auth/src/templates/auth.ts
@@ -3,8 +3,17 @@ import { NextAuthTemplateProps } from '../pages/NextAuthPage';
 
 const template = `
 import getNextAuthPage from '@opensaas/keystone-nextjs-auth/pages/NextAuthPage';
-import { query } from '.keystone/api';
 import keystoneConfig from '../../../../../keystone';
+import { PrismaClient } from '.prisma/client';
+import { createQueryAPI } from '@keystone-6/core/___internal-do-not-use-will-break-in-patch/node-api';
+
+const prisma = global.prisma || PrismaClient
+
+if (process.env.NODE_ENV !== 'production') global.prisma = prisma
+
+const query = global.query || createQueryAPI(keystoneConfig, prisma);
+
+if (process.env.NODE_ENV !== 'production') global.query = query
 
 export default getNextAuthPage({
         autoCreate: <%= autoCreate %>,

--- a/packages/keystone-nextjs-auth/src/templates/auth.ts
+++ b/packages/keystone-nextjs-auth/src/templates/auth.ts
@@ -1,5 +1,5 @@
 import ejs from 'ejs';
-import { CoreNextAuthPageProps } from '../pages/NextAuthPage';
+import { NextAuthTemplateProps } from '../pages/NextAuthPage';
 
 const template = `
 import getNextAuthPage from '@opensaas/keystone-nextjs-auth/pages/NextAuthPage';
@@ -19,15 +19,13 @@ export default getNextAuthPage({
     });
   `;
 
-type AuthTemplateOptions = CoreNextAuthPageProps;
-
 export const authTemplate = ({
   autoCreate,
   identityField,
   listKey,
   sessionData,
   sessionSecret,
-}: AuthTemplateOptions) => {
+}: NextAuthTemplateProps) => {
   const authOut = ejs.render(template, {
     identityField,
     sessionData,


### PR DESCRIPTION
As per https://www.prisma.io/docs/support/help-articles/nextjs-prisma-client-dev-practices
set Prisma client and query to be global in dev

Also allow `get` `start` and `end` session to be configured by user