### PR TITLE
small fixes regarding permission handling

### DIFF
--- a/backend/access.ts
+++ b/backend/access.ts
@@ -81,6 +81,9 @@ export const rules = {
     if (!isSignedIn({ session })) {
       return false;
     }
+    if (permissions.canManageUsers({ session })) {
+      return true;
+    }
     // Otherwise they may only update themselves!
     return { id: { equals: session?.itemId } };
   },

--- a/backend/keystone.ts
+++ b/backend/keystone.ts
@@ -6,6 +6,7 @@ import Auth0 from '@opensaas/keystone-nextjs-auth/providers/auth0';
 import { createAuth } from '@opensaas/keystone-nextjs-auth';
 import { KeystoneContext } from '@keystone-6/core/types';
 import { lists } from './schemas';
+import { permissionsList } from './schemas/permissionFields';
 
 let sessionSecret = process.env.SESSION_SECRET;
 
@@ -22,7 +23,7 @@ const sessionMaxAge = 60 * 60 * 24 * 30; // 30 days
 const auth = createAuth({
   listKey: 'User',
   identityField: 'subjectId',
-  sessionData: `id name email`,
+  sessionData: `id name email role {${permissionsList.join(' ')}}`,
   autoCreate: true,
   resolver: async ({ user, profile }: { user: any; profile: any }) => {
     const name = user.name as string;


### PR DESCRIPTION
1) The backend needs to persist user permissions in the session to check if the user is enabled to do stuff, so we are adding to the session fields all permissions values from the user role
2) the permission check for managing users was incomplete and did prevent users with user management rights to see the whole user list (they could see only their own user)